### PR TITLE
Silence some warnings

### DIFF
--- a/examples/env-ctmrg/env-ctmrg.cc
+++ b/examples/env-ctmrg/env-ctmrg.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include <string>
 #include <iostream>
 #include <fstream>

--- a/examples/env-ctmrg/env-ctmrg.cc
+++ b/examples/env-ctmrg/env-ctmrg.cc
@@ -4,7 +4,9 @@
 #include <fstream>
 #include <chrono>
 #include "json.hpp"
+DISABLE_WARNINGS
 #include "itensor/all.h"
+ENABLE_WARNINGS
 #include "p-ipeps/ctm-cluster-env_v2.h"
 #include "p-ipeps/cluster-ev-builder.h"
 #include "p-ipeps/ctm-cluster-io.h"

--- a/examples/opt-fu-adaptive/opt-fu-adaptive.cc
+++ b/examples/opt-fu-adaptive/opt-fu-adaptive.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include <string>
 #include <iostream>
 #include <fstream>

--- a/examples/opt-su-adaptive/opt-su-adaptive.cc
+++ b/examples/opt-su-adaptive/opt-su-adaptive.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include <string>
 #include <iostream>
 #include <fstream>

--- a/examples/opt-su-adaptive/opt-su-adaptive.cc
+++ b/examples/opt-su-adaptive/opt-su-adaptive.cc
@@ -4,7 +4,9 @@
 #include <fstream>
 #include <chrono>
 #include "json.hpp"
+DISABLE_WARNINGS
 #include "itensor/all.h"
+ENABLE_WARNINGS
 #include "p-ipeps/ctm-cluster-env_v2.h"
 #include "p-ipeps/cluster-ev-builder.h"
 #include "p-ipeps/ctm-cluster-io.h"

--- a/include/p-ipeps/cluster-ev-builder.h
+++ b/include/p-ipeps/cluster-ev-builder.h
@@ -1,6 +1,7 @@
 #ifndef __CLS_EV_BUILDER_
 #define __CLS_EV_BUILDER_
 
+#include "p-ipeps/config.h"
 #include <string>
 #include <iostream>
 #include "itensor/all.h"

--- a/include/p-ipeps/cluster-ev-builder.h
+++ b/include/p-ipeps/cluster-ev-builder.h
@@ -4,7 +4,9 @@
 #include "p-ipeps/config.h"
 #include <string>
 #include <iostream>
+DISABLE_WARNINGS
 #include "itensor/all.h"
+ENABLE_WARNINGS
 #include "p-ipeps/ctm-cluster-global.h"
 #include "p-ipeps/ctm-cluster.h"
 #include "p-ipeps/ctm-cluster-env_v2.h"

--- a/include/p-ipeps/cluster-factory.h
+++ b/include/p-ipeps/cluster-factory.h
@@ -1,6 +1,7 @@
 #ifndef __CLUSTER_FACTORY_
 #define __CLUSTER_FACTORY_
 
+#include "p-ipeps/config.h"
 #include "json.hpp"
 #include "p-ipeps/ctm-cluster.h"
 

--- a/include/p-ipeps/ctm-cluster-basic.h
+++ b/include/p-ipeps/ctm-cluster-basic.h
@@ -7,7 +7,9 @@
 #include <vector>
 #include <map>
 #include "json.hpp"
+DISABLE_WARNINGS
 #include "itensor/all.h"
+ENABLE_WARNINGS
 #include "p-ipeps/ctm-cluster.h"
 
 namespace itensor {

--- a/include/p-ipeps/ctm-cluster-basic.h
+++ b/include/p-ipeps/ctm-cluster-basic.h
@@ -2,6 +2,7 @@
 #define __CLS_BASIC_H_
 
 
+#include "p-ipeps/config.h"
 #include <iostream>
 #include <vector>
 #include <map>

--- a/include/p-ipeps/ctm-cluster-env.h
+++ b/include/p-ipeps/ctm-cluster-env.h
@@ -4,6 +4,7 @@
 #ifndef __CTM_CLS_ENV_H_
 #define __CTM_CLS_ENV_H_
 
+#include "p-ipeps/config.h"
 #include <string>
 #include <iostream>
 #include <vector>

--- a/include/p-ipeps/ctm-cluster-env.h
+++ b/include/p-ipeps/ctm-cluster-env.h
@@ -12,7 +12,9 @@
 #include <chrono>
 #include "p-ipeps/ctm-cluster-io.h"
 #include "p-ipeps/ctm-cluster-global.h"
+DISABLE_WARNINGS
 #include "itensor/all.h"
+ENABLE_WARNINGS
 
 class CtmEnv
 {

--- a/include/p-ipeps/ctm-cluster-env_v2.h
+++ b/include/p-ipeps/ctm-cluster-env_v2.h
@@ -4,6 +4,7 @@
 #ifndef __CTM_CLS_ENV_H_
 #define __CTM_CLS_ENV_H_
 
+#include "p-ipeps/config.h"
 #include <string>
 #include <iostream>
 #include <vector>

--- a/include/p-ipeps/ctm-cluster-env_v2.h
+++ b/include/p-ipeps/ctm-cluster-env_v2.h
@@ -14,7 +14,9 @@
 #include "p-ipeps/ctm-cluster-io.h"
 #include "p-ipeps/ctm-cluster-global.h"
 #include "p-ipeps/linalg/itensor-svd-solvers.h"
+DISABLE_WARNINGS
 #include "itensor/all.h"
+ENABLE_WARNINGS
 
 
 class CtmEnv

--- a/include/p-ipeps/ctm-cluster-global.h
+++ b/include/p-ipeps/ctm-cluster-global.h
@@ -3,7 +3,9 @@
 
 #include "p-ipeps/config.h"
 #include <string>
+DISABLE_WARNINGS
 #include "itensor/all.h"
+ENABLE_WARNINGS
 
 /*
  * ENVironment of nxm cluster 

--- a/include/p-ipeps/ctm-cluster-global.h
+++ b/include/p-ipeps/ctm-cluster-global.h
@@ -1,6 +1,7 @@
 #ifndef __CTM_CLS_GLOBAL_
 #define __CTM_CLS_GLOBAL_
 
+#include "p-ipeps/config.h"
 #include <string>
 #include "itensor/all.h"
 

--- a/include/p-ipeps/ctm-cluster-io.h
+++ b/include/p-ipeps/ctm-cluster-io.h
@@ -15,7 +15,9 @@
 #include "p-ipeps/ctm-cluster-basic.h"
 #include "p-ipeps/ctm-cluster-global.h"
 #include "p-ipeps/cluster-factory.h"
+DISABLE_WARNINGS
 #include "itensor/all.h"
+ENABLE_WARNINGS
 
 const std::string WS4(4,' ');
 

--- a/include/p-ipeps/ctm-cluster-io.h
+++ b/include/p-ipeps/ctm-cluster-io.h
@@ -1,6 +1,7 @@
 #ifndef __CTM_CLS_IO_
 #define __CTM_CLS_IO_
 
+#include "p-ipeps/config.h"
 #include <complex>
 #include <vector>
 #include <string>

--- a/include/p-ipeps/ctm-cluster.h
+++ b/include/p-ipeps/ctm-cluster.h
@@ -4,6 +4,7 @@
 #ifndef __CTM_CLS_H_
 #define __CTM_CLS_H_
 
+#include "p-ipeps/config.h"
 #include <iostream>
 #include <vector>
 #include <map>

--- a/include/p-ipeps/ctm-cluster.h
+++ b/include/p-ipeps/ctm-cluster.h
@@ -125,14 +125,13 @@ struct Cluster {
 
     Cluster() {}
 
-    Cluster(int lX_, int lY_) : lX(lX_), lY(lY_), sizeM(lX_), sizeN(lY_),
-        cluster_type("DEFAULT") {}
+  Cluster(int lX_, int lY_) : cluster_type("DEFAULT"), sizeN(lY_),sizeM(lX_),   lX(lX_), lY(lY_) {}
 
     // Cluster(int lX_, int lY_, int pd) : physDim(pd),
     //     lX(lX_), lY(lY_), sizeM(lX_), sizeN(lY_) {}
 
-    Cluster(int lX_, int lY_, int ad, int pd) : auxBondDim(ad), physDim(pd),
-        lX(lX_), lY(lY_), sizeM(lX_), sizeN(lY_), cluster_type("DEFAULT") {}
+  Cluster(int lX_, int lY_, int ad, int pd) : cluster_type("DEFAULT"), 
+         sizeN(lY_), sizeM(lX_), lX(lX_), lY(lY_), auxBondDim(ad), physDim(pd) {}
 
     static std::unique_ptr<Cluster> create(nlohmann::json const& json_cluster);
 
@@ -162,6 +161,9 @@ struct Cluster {
     void absorbWeightsToSites(bool dbg = false);
 
     void absorbWeightsToLinks(bool dbg = false);
+
+  /** make sure the right dtor is called */
+  virtual ~Cluster() = default;
 };
 
 void initClusterSites(Cluster & c, bool dbg = false);

--- a/include/p-ipeps/ctm-cluster.h
+++ b/include/p-ipeps/ctm-cluster.h
@@ -10,7 +10,9 @@
 #include <map>
 #include "p-ipeps/lattice.h"
 #include "json.hpp"
+DISABLE_WARNINGS
 #include "itensor/all.h"
+ENABLE_WARNINGS
 
 // ############################################################################
 // IO for cluster definition using JSON data format

--- a/include/p-ipeps/engine-factory.h
+++ b/include/p-ipeps/engine-factory.h
@@ -1,6 +1,7 @@
 #ifndef __ENGINE_FACTORY_
 #define __ENGINE_FACTORY_
 
+#include "p-ipeps/config.h"
 #include "json.hpp"
 #include "p-ipeps/engine.h"
 

--- a/include/p-ipeps/engine.h
+++ b/include/p-ipeps/engine.h
@@ -4,7 +4,9 @@
 #include "p-ipeps/config.h"
 #include <string>
 #include "json.hpp"
+DISABLE_WARNINGS
 #include "itensor/all.h"
+ENABLE_WARNINGS
 #include "p-ipeps/cluster-ev-builder.h"
 #include "p-ipeps/ctm-cluster.h"
 #include "p-ipeps/ctm-cluster-global.h"

--- a/include/p-ipeps/engine.h
+++ b/include/p-ipeps/engine.h
@@ -65,6 +65,8 @@ class Engine {
 
         virtual itensor::Args performFullUpdate(
         	Cluster & cls, CtmEnv const& ctmEnv, itensor::Args const& args) = 0;
+  /** make sure the right dtor is invoked */
+  virtual ~Engine() = default;
 };
 
 template <class T>

--- a/include/p-ipeps/engine.h
+++ b/include/p-ipeps/engine.h
@@ -1,6 +1,7 @@
 #ifndef __ENGINE_
 #define __ENGINE_
 
+#include "p-ipeps/config.h"
 #include <string>
 #include "json.hpp"
 #include "itensor/all.h"

--- a/include/p-ipeps/fu-3site-corboz.h
+++ b/include/p-ipeps/fu-3site-corboz.h
@@ -1,6 +1,7 @@
 #ifndef __FULL_UPDT_3S_H_CORBOZ_
 #define __FULL_UPDT_3S_H_CORBOZ_
 
+#include "p-ipeps/config.h"
 #include <cmath>
 #include <limits>
 #include <chrono>

--- a/include/p-ipeps/fu-3site-corboz.h
+++ b/include/p-ipeps/fu-3site-corboz.h
@@ -11,7 +11,9 @@
 #include "p-ipeps/ctm-cluster.h"
 #include "p-ipeps/su2.h"
 #include "p-ipeps/linalg/itensor-linsys-solvers.h"
+DISABLE_WARNINGS
 #include "itensor/all.h"
+ENABLE_WARNINGS
 
 const int IOFFSET = 100;
 

--- a/include/p-ipeps/full-update.h
+++ b/include/p-ipeps/full-update.h
@@ -4,6 +4,7 @@
 #ifndef __FULL_UPDT_H_
 #define __FULL_UPDT_H_
 
+#include "p-ipeps/config.h"
 #include <cmath>
 #include <limits>
 #include <chrono>

--- a/include/p-ipeps/full-update.h
+++ b/include/p-ipeps/full-update.h
@@ -14,7 +14,9 @@
 #include "p-ipeps/ctm-cluster.h"
 #include "p-ipeps/su2.h"
 #include "p-ipeps/linalg/itensor-linsys-solvers.h"
+DISABLE_WARNINGS
 #include "itensor/all.h"
+ENABLE_WARNINGS
 
 itensor::ITensor pseudoInverse(itensor::ITensor const& M,
 	itensor::Args const& args = itensor::Args::global());

--- a/include/p-ipeps/lattice.h
+++ b/include/p-ipeps/lattice.h
@@ -1,6 +1,7 @@
 #ifndef __LATTICE_H_
 #define __LATTICE_H_
 
+#include "p-ipeps/config.h"
 #include <iostream>
 #include <array>
 

--- a/include/p-ipeps/linalg/arpack-rcdn.h
+++ b/include/p-ipeps/linalg/arpack-rcdn.h
@@ -1,6 +1,7 @@
 #ifndef __ARPACK_RCI_H_
 #define __ARPACK_RCI_H_
 
+#include "p-ipeps/config.h"
 // #include "arpack.hpp"
 
 #include <array>

--- a/include/p-ipeps/linalg/itensor-linsys-solvers.h
+++ b/include/p-ipeps/linalg/itensor-linsys-solvers.h
@@ -24,17 +24,17 @@ struct LinSysSolver {
   	
   	virtual void 
     solve(
-      	ITensor & A,
-      	ITensor & B, 
-      	ITensor & X,
-      	Args const& args) const;
+	  ITensor & /*A*/,
+	  ITensor & /*B*/, 
+	  ITensor & /*X*/,
+	  Args const& /*args*/) const;
 
     virtual void 
     solve(
-      	MatRefc<Real>	const& A,
-      	VecRef<Real>  	const& B, 
-      	VecRef<Real>	const& X,
-      	Args const& args) const
+	  MatRefc<Real>	const& /*A*/,
+	  VecRef<Real>  	const& /*B*/, 
+	  VecRef<Real>	const& /*X*/,
+	  Args const& /*args*/) const
     {  
         // To be overloaded by derived classes
         std::cout<<"[LinSysSolver::solve<Real>] called"<<std::endl;
@@ -42,14 +42,17 @@ struct LinSysSolver {
 
     virtual void 
     solve(
-      	MatRefc<Cplx>   const& A,
-      	VecRef<Cplx>	const& B, 
-     	VecRef<Cplx>	const& X, 
-     	Args const& args) const 
+	  MatRefc<Cplx>   const& /*A*/,
+	  VecRef<Cplx>	const& /*B*/, 
+	  VecRef<Cplx>	const& /*X*/, 
+	  Args const& /*args*/) const 
     {  
         // To be overloaded by derived classes
         std::cout<<"[LinSysSolver::solve<Cplx>] called"<<std::endl;
     }
+
+  /** make sure the correct destructor is called */
+  virtual ~LinSysSolver() = default;
 };
 
 struct PseudoInvSolver : LinSysSolver {

--- a/include/p-ipeps/linalg/itensor-linsys-solvers.h
+++ b/include/p-ipeps/linalg/itensor-linsys-solvers.h
@@ -1,6 +1,7 @@
 #ifndef _ITENSOR_LINSYS_SOLVERS_H
 #define _ITENSOR_LINSYS_SOLVERS_H
 
+#include "p-ipeps/config.h"
 #include "itensor/all.h"
 
 namespace itensor {

--- a/include/p-ipeps/linalg/itensor-linsys-solvers.h
+++ b/include/p-ipeps/linalg/itensor-linsys-solvers.h
@@ -2,7 +2,9 @@
 #define _ITENSOR_LINSYS_SOLVERS_H
 
 #include "p-ipeps/config.h"
+DISABLE_WARNINGS
 #include "itensor/all.h"
+ENABLE_WARNINGS
 
 namespace itensor {
 

--- a/include/p-ipeps/linalg/itensor-svd-solvers.h
+++ b/include/p-ipeps/linalg/itensor-svd-solvers.h
@@ -1,6 +1,7 @@
 #ifndef _ITENSOR_SVD_SOLVERS_H
 #define _ITENSOR_SVD_SOLVERS_H
 
+#include "p-ipeps/config.h"
 #include "itensor/all.h"
 
 namespace itensor {

--- a/include/p-ipeps/linalg/itensor-svd-solvers.h
+++ b/include/p-ipeps/linalg/itensor-svd-solvers.h
@@ -2,7 +2,9 @@
 #define _ITENSOR_SVD_SOLVERS_H
 
 #include "p-ipeps/config.h"
+DISABLE_WARNINGS
 #include "itensor/all.h"
+ENABLE_WARNINGS
 
 namespace itensor {
 

--- a/include/p-ipeps/linalg/lapacksvd-solver.h
+++ b/include/p-ipeps/linalg/lapacksvd-solver.h
@@ -1,6 +1,7 @@
 #ifndef _PEPS_LAPACK_SVD_SOLVERS_H
 #define _PEPS_LAPACK_SVD_SOLVERS_H
 
+#include "p-ipeps/config.h"
 #include "p-ipeps/linalg/itensor-svd-solvers.h"
 
 namespace itensor {

--- a/include/p-ipeps/linalg/linsyssolvers-lapack.h
+++ b/include/p-ipeps/linalg/linsyssolvers-lapack.h
@@ -1,6 +1,7 @@
 #ifndef _ITENSOR_LAPACK_LINSYS_SOLVERS_H
 #define _ITENSOR_LAPACK_LINSYS_SOLVERS_H
 
+#include "p-ipeps/config.h"
 #include "p-ipeps/linalg/itensor-linsys-solvers.h"
 
 

--- a/include/p-ipeps/meson.build
+++ b/include/p-ipeps/meson.build
@@ -17,7 +17,8 @@ install_headers(['cluster-ev-builder.h',
                  'rsvd-solver.h',
                  'simple-update_v2.h',
                  'su2.h',
-                 'svdsolver-factory.h'],
+                 'svdsolver-factory.h',
+                 'warnings.h'],
                 subdir:'p-ipeps')
 
 subdir('linalg')

--- a/include/p-ipeps/model-factory.h
+++ b/include/p-ipeps/model-factory.h
@@ -1,6 +1,7 @@
 #ifndef __MODEL_FACTORY_
 #define __MODEL_FACTORY_
 
+#include "p-ipeps/config.h"
 #include "json.hpp"
 #include "p-ipeps/models.h"
 

--- a/include/p-ipeps/models.h
+++ b/include/p-ipeps/models.h
@@ -11,7 +11,9 @@
 #include "p-ipeps/ctm-cluster.h"
 #include "p-ipeps/ctm-cluster-global.h"
 #include "p-ipeps/mpo.h"
+DISABLE_WARNINGS
 #include "itensor/all.h"
+ENABLE_WARNINGS
 
 // ----- Trotter gates (3site, ...) MPOs ------------------------------
 MPO_3site getMPO3s_Ising3Body(double tau, double J1, double J2, double h);

--- a/include/p-ipeps/models.h
+++ b/include/p-ipeps/models.h
@@ -1,6 +1,7 @@
 #ifndef __MODELS_
 #define __MODELS_
 
+#include "p-ipeps/config.h"
 #include <string>
 #include <iostream>
 #include <chrono>

--- a/include/p-ipeps/models/aklt-2x2-ABCD.h
+++ b/include/p-ipeps/models/aklt-2x2-ABCD.h
@@ -1,6 +1,7 @@
 #ifndef __AKLT_2X2_ABCD_
 #define __AKLT_2X2_ABCD_
 
+#include "p-ipeps/config.h"
 #include "p-ipeps/models.h"
 #include "p-ipeps/engine.h"
 

--- a/include/p-ipeps/models/hb-2x2-ABCD.h
+++ b/include/p-ipeps/models/hb-2x2-ABCD.h
@@ -1,6 +1,7 @@
 #ifndef __HB_2X2_ABCD_
 #define __HB_2X2_ABCD_
 
+#include "p-ipeps/config.h"
 #include "p-ipeps/models.h"
 #include "p-ipeps/engine.h"
 

--- a/include/p-ipeps/models/id-2x2-ABCD.h
+++ b/include/p-ipeps/models/id-2x2-ABCD.h
@@ -1,6 +1,7 @@
 #ifndef __ID_2X2_ABCD_
 #define __ID_2X2_ABCD_
 
+#include "p-ipeps/config.h"
 #include "p-ipeps/models.h"
 #include "p-ipeps/engine.h"
 

--- a/include/p-ipeps/models/ising-2x2-ABCD.h
+++ b/include/p-ipeps/models/ising-2x2-ABCD.h
@@ -1,6 +1,7 @@
 #ifndef __ISING_2X2_ABCD_
 #define __ISING_2X2_ABCD_
 
+#include "p-ipeps/config.h"
 #include "p-ipeps/models.h"
 #include "p-ipeps/engine.h"
 

--- a/include/p-ipeps/models/j1j2-2x2-ABCD.h
+++ b/include/p-ipeps/models/j1j2-2x2-ABCD.h
@@ -1,6 +1,7 @@
 #ifndef __J1J2_2X2_ABCD_
 #define __J1J2_2X2_ABCD_
 
+#include "p-ipeps/config.h"
 #include "p-ipeps/models.h"
 #include "p-ipeps/engine.h"
 

--- a/include/p-ipeps/models/ladders-2x2-ABCD.h
+++ b/include/p-ipeps/models/ladders-2x2-ABCD.h
@@ -1,6 +1,7 @@
 #ifndef __LADDERS_2X2_ABCD_
 #define __LADDERS_2X2_ABCD_
 
+#include "p-ipeps/config.h"
 #include "p-ipeps/models.h"
 #include "p-ipeps/engine.h"
 

--- a/include/p-ipeps/mpo.h
+++ b/include/p-ipeps/mpo.h
@@ -1,6 +1,7 @@
 #ifndef __MPO_
 #define __MPO_
 
+#include "p-ipeps/config.h"
 #include "p-ipeps/ctm-cluster.h"
 #include "itensor/all.h"
 

--- a/include/p-ipeps/mpo.h
+++ b/include/p-ipeps/mpo.h
@@ -3,7 +3,9 @@
 
 #include "p-ipeps/config.h"
 #include "p-ipeps/ctm-cluster.h"
+DISABLE_WARNINGS
 #include "itensor/all.h"
+ENABLE_WARNINGS
 
 // ----- Main MPO Structures ------------------------------------------
 // Index names of 3-site MPO indices

--- a/include/p-ipeps/rsvd-solver.h
+++ b/include/p-ipeps/rsvd-solver.h
@@ -2,6 +2,7 @@
 #define _ITENSOR_CUSTOM_SOLVERS_RSVD_H
 
 #include "p-ipeps/config.h"
+#include "p-ipeps/config.h"
 
 #ifdef PEPS_WITH_RSVD
 

--- a/include/p-ipeps/rsvd-solver.h
+++ b/include/p-ipeps/rsvd-solver.h
@@ -1,7 +1,7 @@
 #ifndef _ITENSOR_CUSTOM_SOLVERS_RSVD_H
 #define _ITENSOR_CUSTOM_SOLVERS_RSVD_H
 
-#include "p-ipeps_config.h"
+#include "p-ipeps/config.h"
 
 #ifdef PEPS_WITH_RSVD
 

--- a/include/p-ipeps/simple-update_v2.h
+++ b/include/p-ipeps/simple-update_v2.h
@@ -4,6 +4,7 @@
 #ifndef __SMPL_UPDT_H_
 #define __SMPL_UPDT_H_
 
+#include "p-ipeps/config.h"
 #include <iomanip>
 #include <cmath>
 #include <limits>

--- a/include/p-ipeps/simple-update_v2.h
+++ b/include/p-ipeps/simple-update_v2.h
@@ -13,7 +13,9 @@
 #include "p-ipeps/ctm-cluster.h"
 #include "p-ipeps/ctm-cluster-global.h"
 #include "p-ipeps/su2.h"
+DISABLE_WARNINGS
 #include "itensor/all.h"
+ENABLE_WARNINGS
 
 // ----- 2-Site operator functions ------------------------------------
 

--- a/include/p-ipeps/su2.h
+++ b/include/p-ipeps/su2.h
@@ -5,7 +5,9 @@
 #include <algorithm>
 #include <complex>
 #include <cmath>
+DISABLE_WARNINGS
 #include "itensor/all.h"
+ENABLE_WARNINGS
 
 // Supported types of 1-site operators
 enum SU2O {

--- a/include/p-ipeps/su2.h
+++ b/include/p-ipeps/su2.h
@@ -1,6 +1,7 @@
 #ifndef __SU2_
 #define __SU2_
 
+#include "p-ipeps/config.h"
 #include <algorithm>
 #include <complex>
 #include <cmath>

--- a/include/p-ipeps/svdsolver-factory.h
+++ b/include/p-ipeps/svdsolver-factory.h
@@ -1,6 +1,7 @@
 #ifndef __SVDSOLVER_FACTORY_
 #define __SVDSOLVER_FACTORY_
 
+#include "p-ipeps/config.h"
 #include "json.hpp"
 #include "p-ipeps/linalg/itensor-svd-solvers.h"
 

--- a/include/p-ipeps/warnings.h
+++ b/include/p-ipeps/warnings.h
@@ -1,0 +1,43 @@
+#ifdef COMPILER_HAS_DIAGNOSTIC_PRAGMA
+#define DISABLE_WARNINGS                                                \
+  _Pragma("GCC diagnostic push")                                          \
+  _Pragma("GCC diagnostic ignored \"-Wunknown-pragmas\"")                 \
+  _Pragma("GCC diagnostic ignored \"-Wpragmas\"")                         \
+  _Pragma("GCC diagnostic ignored \"-Wunknown-warning-option\"")          \
+  _Pragma("GCC diagnostic ignored \"-Wunknown-warning\"")                 \
+  _Pragma("GCC diagnostic ignored \"-Wextra\"")                           \
+  _Pragma("GCC diagnostic ignored \"-Waddress-of-packed-member\"")        \
+  _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")         \
+  _Pragma("GCC diagnostic ignored \"-Wexpansion-to-defined\"")            \
+  _Pragma("GCC diagnostic ignored \"-Wexpansion-to-defined\"")            \
+  _Pragma("GCC diagnostic ignored \"-Wignored-attributes\"")              \
+  _Pragma("GCC diagnostic ignored \"-Wignored-qualifiers\"")              \
+  _Pragma("GCC diagnostic ignored \"-Wimplicit-fallthrough\"")            \
+  _Pragma("GCC diagnostic ignored \"-Winfinite-recursion\"")              \
+  _Pragma("GCC diagnostic ignored \"-Wmisleading-indentation\"")          \
+  _Pragma("GCC diagnostic ignored \"-Wmissing-field-initializers\"")      \
+  _Pragma("GCC diagnostic ignored \"-Wnon-virtual-dtor\"")                \
+  _Pragma("GCC diagnostic ignored \"-Woverflow\"")                        \
+  _Pragma("GCC diagnostic ignored \"-Woverloaded-virtual\"")              \
+  _Pragma("GCC diagnostic ignored \"-Wpedantic\"")                        \
+  _Pragma("GCC diagnostic ignored \"-Wstrict-aliasing\"")                 \
+  _Pragma("GCC diagnostic ignored \"-Wtautological-constant-out-of-range-compare\"") \
+  _Pragma("GCC diagnostic ignored \"-Wtype-limits\"")                     \
+  _Pragma("GCC diagnostic ignored \"-Wundef\"")                           \
+  _Pragma("GCC diagnostic ignored \"-Wunused-but-set-parameter\"")        \
+  _Pragma("GCC diagnostic ignored \"-Wunused-but-set-variable\"")         \
+  _Pragma("GCC diagnostic ignored \"-Wunused-function\"")                 \
+  _Pragma("GCC diagnostic ignored \"-Wunused-parameter\"")                \
+  _Pragma("GCC diagnostic ignored \"-Wunused-private-field\"")            \
+  _Pragma("GCC diagnostic ignored \"-Wunused-variable\"")                 \
+  _Pragma("GCC diagnostic ignored \"-Wpragmas\"")
+
+#define ENABLE_WARNINGS \
+  _Pragma("GCC diagnostic pop")
+
+#else
+
+#define DISABLE_WARNINGS
+#define ENABLE_WARNINGS
+
+#endif

--- a/meson/config/meson.build
+++ b/meson/config/meson.build
@@ -1,15 +1,3 @@
-_cdata = configuration_data()
-
-# optional_deps is defined in meson.build in the dependencies folder
-foreach _opt : optional_deps
-    _v = 'PEPS_WITH_'+ _opt.to_upper()
-    _cdata.set(_v, get_variable('with_'+_opt, false))
-endforeach
-
-configure_file(output: short_name+'_config.h',
-               input: 'config.h.in',
-               configuration: _cdata,
-               install: true,
-               install_dir:'include')
 
 include_dirs += include_directories('.')
+subdir('p-ipeps')

--- a/meson/config/p-ipeps/config.h.in
+++ b/meson/config/p-ipeps/config.h.in
@@ -1,11 +1,10 @@
 #ifndef _peps_config_h_meson
 #define _peps_config_h_meson
 
-#mesondefine PEPS_WITH_RSVD
-
-#mesondefine PEPS_WITH_MKL
-
 #mesondefine PEPS_WITH_ARPACK
+#mesondefine PEPS_WITH_LBFGS
+#mesondefine PEPS_WITH_MKL
+#mesondefine PEPS_WITH_RSVD
 
 #mesondefine COMPILER_HAS_DIAGNOSTIC_PRAGMA
 

--- a/meson/config/p-ipeps/config.h.in
+++ b/meson/config/p-ipeps/config.h.in
@@ -7,4 +7,9 @@
 
 #mesondefine PEPS_WITH_ARPACK
 
+#mesondefine COMPILER_HAS_DIAGNOSTIC_PRAGMA
+
+// macros DISABLE_WARNINGS and ENABLE_WARNINGS
+#include "p-ipeps/warnings.h"
+
 #endif

--- a/meson/config/p-ipeps/meson.build
+++ b/meson/config/p-ipeps/meson.build
@@ -1,0 +1,13 @@
+_cdata = configuration_data()
+
+# optional_deps is defined in meson.build in the dependencies folder
+foreach _opt : optional_deps
+    _v = 'PEPS_WITH_'+ _opt.to_upper()
+    _cdata.set(_v, get_variable('with_'+_opt, false))
+endforeach
+
+configure_file(output: 'config.h',
+               input: 'config.h.in',
+               configuration: _cdata,
+               install: true,
+               install_dir:'include/p-ipeps')

--- a/meson/config/p-ipeps/meson.build
+++ b/meson/config/p-ipeps/meson.build
@@ -3,7 +3,7 @@ _cdata = configuration_data()
 # optional_deps is defined in meson.build in the dependencies folder
 foreach _opt : optional_deps
     _v = 'PEPS_WITH_'+ _opt.to_upper()
-    _cdata.set(_v, get_variable('with_'+_opt, false))
+    _cdata.set(_v, get_option(_opt))
 endforeach
 
 

--- a/meson/config/p-ipeps/meson.build
+++ b/meson/config/p-ipeps/meson.build
@@ -6,6 +6,20 @@ foreach _opt : optional_deps
     _cdata.set(_v, get_variable('with_'+_opt, false))
 endforeach
 
+
+code = '''_Pragma("GCC diagnostic push")
+  _Pragma("GCC diagnostic ignored \"-Wextra\"")
+  _Pragma("GCC diagnostic ignored \"-Wunknown-pragmas\"")
+  _Pragma("GCC diagnostic ignored \"-Wpragmas\"")
+  int main() { return 0; }
+  _Pragma("GCC diagnostic pop")
+'''
+
+_pragma = meson.get_compiler('cpp').compiles(code, name: 'pragma check')
+
+_cdata.set('COMPILER_HAS_DIAGNOSTIC_PRAGMA', _pragma)
+
+
 configure_file(output: 'config.h',
                input: 'config.h.in',
                configuration: _cdata,

--- a/meson/dependencies/lbfgs/meson.build
+++ b/meson/dependencies/lbfgs/meson.build
@@ -1,4 +1,3 @@
-set_variable('with_lbfgs', true)
 
 include_dirs += _lbfgs_include # defined in the meson.build in the bundled subdir
 #source_files += _lbfgs_source_files # defined in the meson.build in the bundled subdir

--- a/meson/dependencies/meson.build
+++ b/meson/dependencies/meson.build
@@ -19,11 +19,6 @@ foreach _opt : optional_deps
         # first, we source the subdir where we test we can
         # compile and link and we update the list deps
         subdir(_opt)
-        # everything went fine and we can define a variable
-        # that will be used in the generation of the
-        # config file where we log the features of
-        # our project
-        set_variable('with_'+_opt, true)
     endif
 endforeach
 

--- a/meson/dependencies/meson.build
+++ b/meson/dependencies/meson.build
@@ -13,7 +13,7 @@ foreach _opt : optional_deps
     # from command line either with the option -Dopt
     # or -Dopt-dir
     # there is no need to use both
-    if not _wanted and _dir == ''
+    if not _wanted
         message('Compiling without '+ _opt.to_upper())
     else
         # first, we source the subdir where we test we can

--- a/meson/dependencies/rsvd/meson.build
+++ b/meson/dependencies/rsvd/meson.build
@@ -1,9 +1,7 @@
 # rsvd requires mkl
-if not get_variable('with_mkl')
-    error('RSVD requires MKL. Please reconfigure by either passing -Dmkl=true or -Dmkl-dir=/path/to/mkl.')
+if not get_option('mkl')
+    error('RSVD requires MKL. Please reconfigure by passing -Dmkl=true  and eventually -Dmkl-dir=/path/to/mkl.')
 endif
-
-set_variable('with_rsvd', true)
 
 include_dirs += _rsvd_include # defined in the meson.build in the bundled subdir
 source_files += _rsvd_source_files # defined in the meson.build in the bundled subdir

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,7 +1,5 @@
 option('build-examples', type: 'boolean', value: true)
 
-# TODO these should become type feature
-
 ########### external dependendencies:
 # one option with `library_name`, type boolean
 # one option with `library_name-dir`, type string

--- a/src/cluster-ev-builder.cc
+++ b/src/cluster-ev-builder.cc
@@ -5,7 +5,7 @@ using namespace itensor;
 
 EVBuilder::TransferOpVecProd::TransferOpVecProd(EVBuilder const& ev_, 
     Vertex const& v_, CtmEnv::DIRECTION dir_) 
-    : ev(ev_), v_ref(v_), dir(dir_) {}
+  :  dir(dir_), v_ref(v_), ev(ev_)  {}
 
 void EVBuilder::TransferOpVecProd::operator() (
     double const* const x, 
@@ -228,7 +228,7 @@ void EVBuilder::TransferOpVecProd::operator() (
 
 EVBuilder::TransferOpVecProd_itensor::TransferOpVecProd_itensor(EVBuilder const& ev_, 
     Vertex const& v_, CtmEnv::DIRECTION dir_) 
-    : ev(ev_), v_ref(v_), dir(dir_) {}
+  :  dir(dir_), v_ref(v_),ev(ev_) {}
 
 void EVBuilder::TransferOpVecProd_itensor::operator() (
     ITensor & bT, 

--- a/src/cluster-ev-builder.cc
+++ b/src/cluster-ev-builder.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include "p-ipeps/cluster-ev-builder.h"
 
 using namespace itensor;

--- a/src/cluster-factory.cc
+++ b/src/cluster-factory.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include "p-ipeps/cluster-factory.h"
 #include "p-ipeps/ctm-cluster-basic.h"
 

--- a/src/ctm-cluster-basic.cc
+++ b/src/ctm-cluster-basic.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include "p-ipeps/ctm-cluster-basic.h"
 
 namespace itensor {

--- a/src/ctm-cluster-env_v2.cc
+++ b/src/ctm-cluster-env_v2.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include "p-ipeps/ctm-cluster-env_v2.h"
 
 // TODO Implement convergence check as general function. The actual

--- a/src/ctm-cluster-env_v2.cc
+++ b/src/ctm-cluster-env_v2.cc
@@ -19,7 +19,7 @@ using namespace itensor;
 CtmEnv::CtmEnv (
     std::string t_name, int t_x, Cluster const& c, 
     SvdSolver & ssolver, Args const& args) 
-    : m_name(t_name), p_cluster(&c), solver(ssolver), 
+  :  p_cluster(&c), solver(ssolver), m_name(t_name), 
     d(c.auxBondDim*c.auxBondDim), x(t_x), 
     sizeN(c.sizeN), sizeM(c.sizeM) 
     {

--- a/src/ctm-cluster-io.cc
+++ b/src/ctm-cluster-io.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include "p-ipeps/ctm-cluster-io.h"
 
 using namespace std;

--- a/src/ctm-cluster.cc
+++ b/src/ctm-cluster.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include "p-ipeps/ctm-cluster.h"
 
 using namespace itensor;

--- a/src/ctmrg.cc
+++ b/src/ctmrg.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include "p-ipeps/ctm-cluster-env_v2.h"
 
 using namespace itensor;

--- a/src/engine-factory.cc
+++ b/src/engine-factory.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include "p-ipeps/engine-factory.h"
 #include "p-ipeps/models/id-2x2-ABCD.h"
 #include "p-ipeps/models/ising-2x2-ABCD.h"

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include "p-ipeps/engine.h"
 
 using namespace itensor;

--- a/src/fu-2site.cc
+++ b/src/fu-2site.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include "p-ipeps/full-update.h"
 
 using namespace itensor;

--- a/src/fu-3site-corboz.cc
+++ b/src/fu-3site-corboz.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include "p-ipeps/fu-3site-corboz.h"
 
 using namespace itensor;

--- a/src/fu-3site.cc
+++ b/src/fu-3site.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 // #include "full-update-TEST.h"
 #include "p-ipeps/full-update.h"
 

--- a/src/fu-4site.cc
+++ b/src/fu-4site.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include "p-ipeps/full-update.h"
 #include "include/LBFGS.h"
 

--- a/src/full-update-TEST.cc
+++ b/src/full-update-TEST.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include "full-update-TEST.h"
 
 using namespace itensor;

--- a/src/full-update.cc
+++ b/src/full-update.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include "p-ipeps/full-update.h"
 
 using namespace itensor;

--- a/src/lattice.cc
+++ b/src/lattice.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include "p-ipeps/lattice.h"
 
 // namespace itensor { 

--- a/src/linalg/itensor-linsys-solvers.cc
+++ b/src/linalg/itensor-linsys-solvers.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include "p-ipeps/linalg/itensor-linsys-solvers.h" 
 
 namespace itensor {

--- a/src/linalg/itensor-svd-solvers.cc
+++ b/src/linalg/itensor-svd-solvers.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include <algorithm>
 #include <tuple>
 #include "p-ipeps/linalg/itensor-svd-solvers.h" 

--- a/src/linalg/rsvd-solver.cc
+++ b/src/linalg/rsvd-solver.cc
@@ -1,4 +1,5 @@
 #include "p-ipeps/config.h"
+#include "p-ipeps/config.h"
 
 #ifdef PEPS_WITH_RSVD
 

--- a/src/linalg/rsvd-solver.cc
+++ b/src/linalg/rsvd-solver.cc
@@ -1,4 +1,4 @@
-#include "p-ipeps_config.h"
+#include "p-ipeps/config.h"
 
 #ifdef PEPS_WITH_RSVD
 

--- a/src/model-factory.cc
+++ b/src/model-factory.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include "p-ipeps/model-factory.h"
 #include "p-ipeps/models/ising-2x2-ABCD.h"
 #include "p-ipeps/models/hb-2x2-ABCD.h"

--- a/src/models.cc
+++ b/src/models.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include "p-ipeps/models.h"
 
 using namespace itensor;

--- a/src/models/aklt-2x2-ABCD.cc
+++ b/src/models/aklt-2x2-ABCD.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include "p-ipeps/models/aklt-2x2-ABCD.h"
 
 namespace itensor {

--- a/src/models/hb-2x2-ABCD.cc
+++ b/src/models/hb-2x2-ABCD.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include "p-ipeps/models/hb-2x2-ABCD.h"
 
 namespace itensor {

--- a/src/models/id-2x2-ABCD.cc
+++ b/src/models/id-2x2-ABCD.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include "p-ipeps/models/id-2x2-ABCD.h"
 
 namespace itensor {

--- a/src/models/ising-2x2-ABCD.cc
+++ b/src/models/ising-2x2-ABCD.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include "p-ipeps/models/ising-2x2-ABCD.h"
 
 namespace itensor {

--- a/src/models/j1j2-2x2-ABCD.cc
+++ b/src/models/j1j2-2x2-ABCD.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include "p-ipeps/models/j1j2-2x2-ABCD.h"
 
 namespace itensor {

--- a/src/models/ladders-2x2-ABCD.cc
+++ b/src/models/ladders-2x2-ABCD.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include "p-ipeps/models/ladders-2x2-ABCD.h"
 
 namespace itensor {

--- a/src/mpo.cc
+++ b/src/mpo.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include "p-ipeps/mpo.h"
 
 using namespace itensor;

--- a/src/simple-update_v2.cc
+++ b/src/simple-update_v2.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include "p-ipeps/simple-update_v2.h"
 
 using namespace itensor;

--- a/src/su2.cc
+++ b/src/su2.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include "p-ipeps/su2.h"
 
 using namespace std;

--- a/src/svdsolver-factory.cc
+++ b/src/svdsolver-factory.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include "p-ipeps/svdsolver-factory.h"
 #include "p-ipeps/rsvd-solver.h"
 #include "p-ipeps/linalg/lapacksvd-solver.h"

--- a/tests/test-arpack-itensor.cc
+++ b/tests/test-arpack-itensor.cc
@@ -1,6 +1,8 @@
 #include "p-ipeps/config.h"
 #include "p-ipeps/linalg/arpack-rcdn.h"
+DISABLE_WARNINGS
 #include "itensor/all.h"
+ENABLE_WARNINGS
 	
 struct DiagMVP {
 	int id;

--- a/tests/test-arpack-itensor.cc
+++ b/tests/test-arpack-itensor.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include "p-ipeps/linalg/arpack-rcdn.h"
 #include "itensor/all.h"
 	

--- a/tests/test-arpack.cc
+++ b/tests/test-arpack.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include "arpack.hpp"
 
 #include <array>

--- a/tests/test-mklsvd.cc
+++ b/tests/test-mklsvd.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include <iostream>
 #include "itensor/all.h"
 #include <chrono>

--- a/tests/test-mklsvd.cc
+++ b/tests/test-mklsvd.cc
@@ -1,6 +1,8 @@
 #include "p-ipeps/config.h"
 #include <iostream>
+DISABLE_WARNINGS
 #include "itensor/all.h"
+ENABLE_WARNINGS
 #include <chrono>
 
 using namespace itensor;

--- a/tests/unit_tests/example.cc
+++ b/tests/unit_tests/example.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include <gtest/gtest.h>
 // additional include needed for this test from this project
 #include "p-ipeps/engine.h"

--- a/tests/unit_tests/test-cluster.cc
+++ b/tests/unit_tests/test-cluster.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include <iostream>
 #include <string>
 #include <gtest/gtest.h>

--- a/tests/unit_tests/test-ctm-env.cc
+++ b/tests/unit_tests/test-ctm-env.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include <iostream>
 #include <gtest/gtest.h>
 #include "p-ipeps/ctm-cluster-basic.h"

--- a/tests/unit_tests/test-gesdd-svd-solver.cc
+++ b/tests/unit_tests/test-gesdd-svd-solver.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include <gtest/gtest.h>
 #include <iostream>
 #include "itensor/all.h"

--- a/tests/unit_tests/test-gesdd-svd-solver.cc
+++ b/tests/unit_tests/test-gesdd-svd-solver.cc
@@ -1,7 +1,9 @@
 #include "p-ipeps/config.h"
 #include <gtest/gtest.h>
 #include <iostream>
+DISABLE_WARNINGS
 #include "itensor/all.h"
+ENABLE_WARNINGS
 #include "p-ipeps/linalg/lapacksvd-solver.h"
 
 using namespace itensor;

--- a/tests/unit_tests/test-lin-sys.cc
+++ b/tests/unit_tests/test-lin-sys.cc
@@ -1,7 +1,9 @@
 #include "p-ipeps/config.h"
 #include <gtest/gtest.h>
 #include <iostream>
+DISABLE_WARNINGS
 #include "itensor/all.h"
+ENABLE_WARNINGS
 #include "p-ipeps/linalg/linsyssolvers-lapack.h"
 
 using namespace itensor;

--- a/tests/unit_tests/test-lin-sys.cc
+++ b/tests/unit_tests/test-lin-sys.cc
@@ -1,3 +1,4 @@
+#include "p-ipeps/config.h"
 #include <gtest/gtest.h>
 #include <iostream>
 #include "itensor/all.h"


### PR DESCRIPTION
@jurajHasik , I silenced some warnings:
- base classes that didn't have a virtual destructor
- wrong order of member initialization

I leave to you the warnings about unused variables..